### PR TITLE
Update template.yaml

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -150,9 +150,7 @@ Resources:
                 ViewerProtocolPolicy: redirect-to-https
             Restrictions:
                 GeoRestriction:
-                    RestrictionType: whitelist
-                    Locations:
-                        - US
+                    RestrictionType: none
 
     CFWebsiteCreatorRole:
         Type: "AWS::IAM::Role"


### PR DESCRIPTION
Setting RestrictionType to none so that access to content is not restricted by client geo location

*Issue #1 , The Amazon CloudFront distribution is configured to block access from countries other than US*

*Description of changes:*
Setting RestrictionType to none so that access to content is not restricted by client geo location

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
